### PR TITLE
[ADD] Set Provider For Invoice, Hide server action and view fixes for old case manager and provider fields.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc 
+

--- a/custom_sale_order/__manifest__.py
+++ b/custom_sale_order/__manifest__.py
@@ -6,7 +6,7 @@
     'depends': ['sale','project','account','mail'],
     'data': [
         'data/mail_template.xml',
-        'data/server_action.xml',
+        # 'data/server_action.xml',
         'views/sale_order_views.xml',
         'views/account_move.xml',
         'views/product_product.xml',

--- a/custom_sale_order/models/sale_order.py
+++ b/custom_sale_order/models/sale_order.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import timedelta
 
-from odoo import _,api, fields, models
+from odoo import _,api, fields, models, Command, _
 from odoo.exceptions import UserError, ValidationError
 import logging
 _logger = logging.getLogger(__name__)
@@ -209,6 +209,48 @@ class SaleOrder(models.Model):
                 }
             )
             _logger.info('Swapped Partner_Id --> %s  Shipping Id --> %s', record.partner_id.display_name,record.partner_shipping_id.display_name)
+    
+        # INVOICING #
+        # To Create invoice for the Provider Field
+    def _prepare_invoice(self):
+        """
+        Prepare the dict of values to create the new invoice for a sales order. This method may be
+        overridden to implement custom invoice generation (making sure to call super() to establish
+        a clean extension chain).
+        """
+        self.ensure_one()
+
+        txs_to_be_linked = self.transaction_ids.sudo().filtered(
+            lambda tx: (
+                tx.state in ('pending', 'authorized')
+                or tx.state == 'done' and not (tx.payment_id and tx.payment_id.is_reconciled)
+            )
+        )
+
+        values = {
+            'ref': self.client_order_ref or '',
+            'move_type': 'out_invoice',
+            'narration': self.note,
+            'currency_id': self.currency_id.id,
+            'campaign_id': self.campaign_id.id,
+            'medium_id': self.medium_id.id,
+            'source_id': self.source_id.id,
+            'team_id': self.team_id.id,
+            'partner_id': self.provider_id.id,
+            'partner_shipping_id': self.partner_shipping_id.id,
+            'fiscal_position_id': (self.fiscal_position_id or self.fiscal_position_id._get_fiscal_position(self.provider_id)).id,
+            'invoice_origin': self.name,
+            'invoice_payment_term_id': self.payment_term_id.id,
+            'invoice_user_id': self.user_id.id,
+            'payment_reference': self.reference,
+            'transaction_ids': [Command.set(txs_to_be_linked.ids)],
+            'company_id': self.company_id.id,
+            'invoice_line_ids': [],
+            'user_id': self.user_id.id,
+        }
+        if self.journal_id:
+            values['journal_id'] = self.journal_id.id
+        return values
 
 
 class SaleAdvancePaymentInv(models.TransientModel):

--- a/custom_sale_order/views/sale_order_views.xml
+++ b/custom_sale_order/views/sale_order_views.xml
@@ -6,16 +6,22 @@
         <field name="model">sale.order</field>
         <field name="inherit_id" ref="sale.view_order_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='partner_shipping_id']" position="attributes">
+
+            <!-- OLD LOGIC!!!! -->
+            <!-- <xpath expr="//field[@name='partner_shipping_id']" position="attributes">
                 <attribute name="context">{'show_address': 1}</attribute>
                 <attribute name="string">Case Manager</attribute>
             </xpath>
 
             
             <xpath expr="//field[@name='partner_invoice_id']" position="attributes">
-                <attribute name="string">Provider</attribute>
+                <attribute name="string">Provider Invoice Address</attribute>
 
             </xpath>
+ -->
+
+            <!-- OLD LOGIC!!!! -->
+
             <xpath expr="//field[@name='validity_date']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>


### PR DESCRIPTION
To Make Sale Orders To Be Tracked On Client (Res Partner) Record Following was Done.
1. Created Two Custom Fields For Provider and Case Manager.
2. Delivery Address For Client is now Partner_id field in Sale Order.
3. Fixed The view both Form and list view.
4. Following fields have been fixed as well Client name, Details, Provider as they were related fields on List view.
5. Server Action was created to fix the data as case manager and delivery address now needed to be swapped as case manager previously was partner_id. Also putting in the data on custom fields Provider and Case Manager as well.
6. Now Sale Order is linked to client put on delivery address field.
7. Changed the email templates also changes as well (partner_to) so it sends the email to case manager.
8. Prepare Invoice Vals also over written so invoice is created to Provider selected on custom field now. (Provider)